### PR TITLE
Bulk discounts delete

### DIFF
--- a/app/controllers/merchant_bulk_discounts_controller.rb
+++ b/app/controllers/merchant_bulk_discounts_controller.rb
@@ -18,6 +18,12 @@ class MerchantBulkDiscountsController < ApplicationController
     end
   end
 
+  def destroy 
+    bulk_discount = BulkDiscount.find(params[:bulk_discount_id])
+    bulk_discount.destroy
+    redirect_to "/merchants/#{params[:merchant_id]}/bulk_discounts"
+  end
+
   private 
   def bulk_discount_params
     params.permit(:percentage, :quantity_threshold, :merchant_id)

--- a/app/views/merchant_bulk_discounts/index.html.erb
+++ b/app/views/merchant_bulk_discounts/index.html.erb
@@ -4,8 +4,12 @@
   <% @merchant.bulk_discounts.each do |discount| %>
     <div id="discount-<%= discount.id %>">
       <h4>Percentage Discount: <%= discount.percentage %>%, Quantity Threshold: <%= discount.quantity_threshold %></h4>
+      <h5><%= link_to 'Delete Bulk Discount', "/merchants/#{@merchant.id}/bulk_discounts/#{discount.id}", method: :delete %></h5>
       <h5><%= link_to 'Bulk Discount Page', "/merchants/#{@merchant.id}/bulk_discounts/#{discount.id}" %></h5>
+    </div>
     </div>
   <% end %>
 
 <h5><%= link_to 'Create New Bulk Discount', "/merchants/#{@merchant.id}/bulk_discounts/new" %></h5>
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,10 @@ Rails.application.routes.draw do
   get '/merchants/:merchant_id/bulk_discounts', to:'merchant_bulk_discounts#index'
   get '/merchants/:merchant_id/bulk_discounts/new', to: 'merchant_bulk_discounts#new'
   post '/merchants/:merchant_id/bulk_discounts/create', to: 'merchant_bulk_discounts#create'
+  delete '/merchants/:merchant_id/bulk_discounts/:bulk_discount_id', to: 'merchant_bulk_discounts#destroy'
   get '/merchants/:merchant_id/bulk_discounts/:bulk_discount_id', to: 'bulk_discounts#show'
+
+
   
   get '/admin', to: 'admin#dashboard'
  

--- a/spec/features/merchants/bulk_discounts/index_spec.rb
+++ b/spec/features/merchants/bulk_discounts/index_spec.rb
@@ -173,4 +173,63 @@ RSpec.describe "Merchant's Bulk Discounts Index", type: :feature do
       expect(page).to have_link('Bulk Discount Page')
     end
   end
+
+  it "can delete a bulk discount" do 
+    merchant1 = Merchant.create!(name: "Poke Retirement homes")
+    discount1 = BulkDiscount.create!(percentage: 20, quantity_threshold: 10, merchant_id: merchant1.id)
+    discount2 = BulkDiscount.create!(percentage: 25, quantity_threshold: 15, merchant_id: merchant1.id)
+    discount3 = BulkDiscount.create!(percentage: 30, quantity_threshold: 20, merchant_id: merchant1.id)
+
+    merchant2 = Merchant.create!(name: "Rendolyn Guiz's poke stops")
+    discount4 = BulkDiscount.create!(percentage: 10, quantity_threshold: 10, merchant_id: merchant2.id)
+    discount5 = BulkDiscount.create!(percentage: 15, quantity_threshold: 15, merchant_id: merchant2.id)
+    discount6 = BulkDiscount.create!(percentage: 20, quantity_threshold: 20, merchant_id: merchant2.id)
+
+    merchant3 = Merchant.create!(name: "Dhirley Secasrio's knits and bits")
+    discount7 = BulkDiscount.create!(percentage: 5, quantity_threshold: 10, merchant_id: merchant3.id)
+    discount8 = BulkDiscount.create!(percentage: 10, quantity_threshold: 15, merchant_id: merchant3.id)
+    discount9 = BulkDiscount.create!(percentage: 15, quantity_threshold: 20, merchant_id: merchant3.id)
+
+    visit "/merchants/#{merchant1.id}/bulk_discounts"
+
+    expect(page).to have_content("Percentage Discount: 20%")
+    expect(page).to have_content("Quantity Threshold: 10")
+    expect(page).to have_link('Delete Bulk Discount') 
+
+    within "div#discount-#{discount1.id}" do
+      click_on ('Delete Bulk Discount')
+    end
+
+    expect(current_path).to eq("/merchants/#{merchant1.id}/bulk_discounts")
+    expect(page).to_not have_content("Percentage Discount: 20%")
+    expect(page).to_not have_content("Quantity Threshold: 10")
+
+    visit "/merchants/#{merchant2.id}/bulk_discounts"
+
+    expect(page).to have_content("Percentage Discount: 15%")
+    expect(page).to have_content("Quantity Threshold: 15")
+    expect(page).to have_link('Delete Bulk Discount') 
+
+    within "div#discount-#{discount5.id}" do
+      click_on ('Delete Bulk Discount')
+    end
+
+    expect(current_path).to eq("/merchants/#{merchant2.id}/bulk_discounts")
+    expect(page).to_not have_content("Percentage Discount: 15%")
+    expect(page).to_not have_content("Quantity Threshold: 15")
+
+    visit "/merchants/#{merchant3.id}/bulk_discounts"
+
+    expect(page).to have_content("Percentage Discount: 15%")
+    expect(page).to have_content("Quantity Threshold: 20")
+    expect(page).to have_link('Delete Bulk Discount') 
+
+    within "div#discount-#{discount9.id}" do
+      click_on ('Delete Bulk Discount')
+    end
+
+    expect(current_path).to eq("/merchants/#{merchant3.id}/bulk_discounts")
+    expect(page).to_not have_content("Percentage Discount: 15%")
+    expect(page).to_not have_content("Quantity Threshold: 20")  
+  end
 end


### PR DESCRIPTION
User story 3 -- completed 

Merchant Bulk Discount Delete
As a merchant
When I visit my bulk discounts index
Then next to each bulk discount I see a link to delete it
When I click this link
Then I am redirected back to the bulk discounts index page
And I no longer see the discount listed

Updated controller, views, routes to be able to delete bulk discount. 