### PR TITLE
Bulk discount edit

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -1,3 +1,17 @@
 class BulkDiscountsController < ApplicationController
 
+  def edit 
+    @discount = BulkDiscount.find(params[:bulk_discount_id])
+  end
+  
+  def update 
+    discount = BulkDiscount.find(params[:bulk_discount_id])
+    discount.update(bulk_discount_params)
+    redirect_to "/merchants/#{discount.merchant_id}/bulk_discounts/#{discount.id}"
+  end
 end
+
+private 
+  def bulk_discount_params
+    params.permit(:percentage, :quantity_threshold, :merchant_id)
+  end

--- a/app/views/bulk_discounts/edit.html.erb
+++ b/app/views/bulk_discounts/edit.html.erb
@@ -1,0 +1,9 @@
+<%= form_with url: "/bulk_discounts/#{@discount.id}/update", method: :patch, local: true do |form| %>
+  <%= form.label :percentage %>
+  <%= form.text_field :percentage, value: @discount.percentage %>
+
+  <%= form.label :quantity_threshold %>
+  <%= form.text_field :quantity_threshold, value: @discount.quantity_threshold %>
+
+  <%= form.submit 'Submit' %>
+<% end %>

--- a/app/views/merchant_bulk_discounts/show.html.erb
+++ b/app/views/merchant_bulk_discounts/show.html.erb
@@ -1,3 +1,5 @@
 <h1>Merchant Bulk Discount Show Page</h1>
 
 <h4>Percentage Discount: <%= @discount.percentage %>%, Quantity Threshold: <%= @discount.quantity_threshold %></h4>
+
+<h5><%= link_to 'Edit Bulk Discount', "/bulk_discounts/#{@discount.id}/edit", method: :get %></h5>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,8 @@ Rails.application.routes.draw do
   post '/merchants/:merchant_id/bulk_discounts/create', to: 'merchant_bulk_discounts#create'
   delete '/merchants/:merchant_id/bulk_discounts/:bulk_discount_id', to: 'merchant_bulk_discounts#destroy'
   get '/merchants/:merchant_id/bulk_discounts/:bulk_discount_id', to: 'merchant_bulk_discounts#show'
+  get '/bulk_discounts/:bulk_discount_id/edit', to: 'bulk_discounts#edit'
+  patch '/bulk_discounts/:bulk_discount_id/update', to: 'bulk_discounts#update'
   
   get '/admin', to: 'admin#dashboard'
  

--- a/spec/bulk_discounts/edit_spec.rb
+++ b/spec/bulk_discounts/edit_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe "Bulk Discount Edit Page", type: :feature do 
+
+# Merchant Bulk Discount Edit
+
+# As a merchant
+# When I visit my bulk discount show page
+# Then I see a link to edit the bulk discount
+# When I click this link
+# Then I am taken to a new page with a form to edit the discount
+# And I see that the discounts current attributes are pre-poluated in the form
+# When I change any/all of the information and click submit
+# Then I am redirected to the bulk discount's show page
+# And I see that the discount's attributes have been updated
+
+  it "has a link on the bulk discount show page to edit the bulk discount" do 
+    merchant1 = Merchant.create!(name: "Poke Retirement homes")
+    discount1 = BulkDiscount.create!(percentage: 20, quantity_threshold: 10, merchant_id: merchant1.id)
+    discount2 = BulkDiscount.create!(percentage: 25, quantity_threshold: 15, merchant_id: merchant1.id)
+    discount3 = BulkDiscount.create!(percentage: 30, quantity_threshold: 20, merchant_id: merchant1.id)
+
+    merchant2 = Merchant.create!(name: "Rendolyn Guiz's poke stops")
+    discount4 = BulkDiscount.create!(percentage: 10, quantity_threshold: 10, merchant_id: merchant2.id)
+    discount5 = BulkDiscount.create!(percentage: 15, quantity_threshold: 15, merchant_id: merchant2.id)
+    discount6 = BulkDiscount.create!(percentage: 20, quantity_threshold: 20, merchant_id: merchant2.id)
+
+    merchant3 = Merchant.create!(name: "Dhirley Secasrio's knits and bits")
+    discount7 = BulkDiscount.create!(percentage: 5, quantity_threshold: 10, merchant_id: merchant3.id)
+    discount8 = BulkDiscount.create!(percentage: 10, quantity_threshold: 15, merchant_id: merchant3.id)
+    discount9 = BulkDiscount.create!(percentage: 15, quantity_threshold: 20, merchant_id: merchant3.id)
+
+    visit "/merchants/#{merchant1.id}/bulk_discounts/#{discount1.id}"
+
+    expect(page).to have_content("Percentage Discount: 20%")
+    expect(page).to have_content("Quantity Threshold: 10")
+    expect(page).to have_link('Edit Bulk Discount') 
+    
+    click_on ('Edit Bulk Discount')
+    expect(current_path).to eq("/bulk_discounts/#{discount1.id}/edit")
+
+    fill_in 'percentage', with: '15'
+    fill_in 'quantity_threshold', with: '25'
+    click_on ('Submit')
+
+    expect(current_path).to eq("/merchants/#{merchant1.id}/bulk_discounts/#{discount1.id}")
+    expect(page).to have_content("Percentage Discount: 15%")
+    expect(page).to have_content("Quantity Threshold: 25")
+
+    visit "/merchants/#{merchant3.id}/bulk_discounts/#{discount8.id}"
+
+    expect(page).to have_content("Percentage Discount: 10%")
+    expect(page).to have_content("Quantity Threshold: 15")
+    expect(page).to have_link('Edit Bulk Discount') 
+    
+    click_on ('Edit Bulk Discount')
+    expect(current_path).to eq("/bulk_discounts/#{discount8.id}/edit")
+
+    fill_in 'percentage', with: '25'
+    fill_in 'quantity_threshold', with: '45'
+    click_on ('Submit')
+
+    expect(current_path).to eq("/merchants/#{merchant3.id}/bulk_discounts/#{discount8.id}")
+    expect(page).to have_content("Percentage Discount: 25%")
+    expect(page).to have_content("Quantity Threshold: 45")
+  end
+end


### PR DESCRIPTION
User story 5 -- completed 

Merchant Bulk Discount Edit

As a merchant
When I visit my bulk discount show page
Then I see a link to edit the bulk discount
When I click this link
Then I am taken to a new page with a form to edit the discount
And I see that the discounts current attributes are pre-poluated in the form
When I change any/all of the information and click submit
Then I am redirected to the bulk discount's show page
And I see that the discount's attributes have been updated

updated bulk_discount controller with edit/update methods, updated routes for get/patch, creeated edit spec file for tests, created edit file for updated form 