### PR TITLE
Merchant bulk discount show

### DIFF
--- a/app/models/bulk_discount.rb
+++ b/app/models/bulk_discount.rb
@@ -1,5 +1,6 @@
 class BulkDiscount < ApplicationRecord
   belongs_to :merchant
+  has_many :invoices, through: :merchant
 
   validates_presence_of :percentage
   validates_presence_of :quantity_threshold

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -7,15 +7,12 @@ class Invoice < ApplicationRecord
   has_many :transactions, dependent: :destroy
   has_many :items, through: :invoice_items
   has_many :merchants, through: :items
+  has_many :bulk_discounts, through: :merchants
 
   validates_presence_of :status
 
-  def total_revenue(merchant_id)
-    invoice_items
-    .joins(:item)
-    .where(items: { merchant_id: merchant_id })
-    .sum('invoice_items.unit_price * invoice_items.quantity')
-    require 'pry'; binding.pry
+  def total_revenue
+    invoice_items.sum("unit_price * quantity")
   end
 
   def self.incomplete_invoices
@@ -24,6 +21,18 @@ class Invoice < ApplicationRecord
     .distinct
     .order(:created_at)
   end
+
+  def revenue_with_discount
+    invoice_items.joins(:bulk_discounts)
+    .select("invoice_items.id, max(invoice_items.unit_price * invoice_items.quantity * (bulk_discounts.percentage / 100.00)) AS discount")
+    .where("invoice_items.quantity >= bulk_discounts.quantity_threshold")
+    .group("invoice_items.id")
+    .sum(&:discount).to_i
+  end
+
+  def discounted_revenue
+    total_revenue - revenue_with_discount
+  end 
 end
 
  

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -6,13 +6,9 @@ class InvoiceItem < ApplicationRecord
 
     has_one :merchant, through: :item
     has_many :transactions, through: :invoice
+    has_many :bulk_discounts, through: :merchant
 
     validates_presence_of :quantity
     validates_presence_of :unit_price
     validates_presence_of :status
-
-    def bulk_discount
-        
-        # .where(quantity_threshold: { merchant_id: merchant_id })
-    end
 end

--- a/app/views/admin/show.html.erb
+++ b/app/views/admin/show.html.erb
@@ -1,5 +1,5 @@
 <div id="revenue">
-  <h3>Total Revenue: <%="#{@invoice.total_revenue(@invoice.merchants.ids)}" %></h3>
+  <h3>Total revenue: <%="#{@invoice.total_revenue}" %></h3>
 </div>
 <%= form_with url: "/admin/invoices/#{@invoice.id}/update", method: :patch, local: true do |form| %>
 <strong><%= form.label :status %></strong>

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -3,19 +3,19 @@
 <h1 id="myHeader">Little Esty Shop</h1>
 
 <div id="merchantLinks">
-  <span id="merchantName">Poke Retirement homes</span>
+  <span id="merchantName">@merchant.name</span>
     <span class="links">Dashboard</span>
     <span class="links">My Items</span>
     <span class="links">My Invoices</span>
 </div>
 
 <div id="revenue">
-  <h3>Total Revenue: <%="#{@invoice.total_revenue(@merchant.id)}" %></h3>
+  <h3>Total revenue: <%="#{@invoice.total_revenue}" %></h3>
+  <h3>Total revenue with bulk discount: <%= @invoice.discounted_revenue %></h3>
 </div>
 
 <div id="invoice">
   <% @invoice.invoice_items.each do |invoice| %>
-  <%= invoice.item.id %>
     <% if @merchant.items.include?(invoice.item) %>
       <p>Name: <%= invoice.item.name %></p>
       <p>Quantity: <%= invoice.quantity %></p>
@@ -36,7 +36,6 @@
   <p>Created on: <%= @invoice.created_at.strftime("%A, %B %e, %Y") %></p>
   <p>Customer: <%= @invoice.customer.first_name %> <%= @invoice.customer.last_name %></p>
 </div>
-
 </div>
 
 

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -81,8 +81,8 @@ RSpec.describe 'Admin Invoices Item Index' do
               expect(page).to have_content(1)
               expect(page).to have_content(1000)
               expect(page).to have_content("shipped")
-              expect(page).to have_content("Total Revenue: 1000")
-              expect(page).to_not have_content("Total Revenue: 2000")
+              expect(page).to have_content("Total revenue: 1000")
+              expect(page).to_not have_content("Total revenue: 2000")
 
             end
 
@@ -110,8 +110,8 @@ RSpec.describe 'Admin Invoices Item Index' do
               expect(page).to have_content(1)
               expect(page).to have_content(1000)
               expect(page).to have_content("shipped")
-              expect(page).to have_content("Total Revenue: 2000")
-              expect(page).to_not have_content("Total Revenue: 1000")
+              expect(page).to have_content("Total revenue: 2000")
+              expect(page).to_not have_content("Total revenue: 1000")
             end
 
 

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -98,19 +98,20 @@ RSpec.describe 'merchants invoice show page', type: :feature do
     visit "/merchants/#{merchant1.id}/invoices/#{invoice1.id}"
 
     within "div#revenue" do
-      expect(page).to have_content("Total Revenue: 1000")
+      expect(page).to have_content("Total revenue: 1000")
       expect(page).to_not have_content("2000")
     end
 
     visit "/merchants/#{merchant2.id}/invoices/#{invoice2.id}"
     within "div#revenue" do
-      expect(page).to have_content("Total Revenue: 4000")
+      expect(page).to have_content("Total revenue: 4000")
       expect(page).to_not have_content("1000")
     end
 
     visit "/merchants/#{merchant3.id}/invoices/#{invoice3.id}"
+
     within "div#revenue" do
-      expect(page).to have_content("Total Revenue: 1500")
+      expect(page).to have_content("Total revenue: 1500")
       expect(page).to_not have_content("1000")
       expect(page).to_not have_content("4000")
     end
@@ -170,16 +171,7 @@ RSpec.describe 'merchants invoice show page', type: :feature do
     expect(page).to have_field(:status, with: "Shipped")
   end
 
-# As a merchant
-# When I visit my merchant invoice show page
-# Then I see the total revenue for my merchant 
-# from this invoice (not including discounts)
-# And I see the total discounted revenue for my merchant 
-# from this invoice which includes bulk discounts 
-# in the calculation
-
   it "can list total revenue from an invoice with and without bulk discounts applied" do 
-    # Merchant 1 
     merchant1 = Merchant.create!(name: "Poke Retirement homes")
     item1 = Item.create!(name: "Pikachu pics", description: 'Cute pics with pikachu', unit_price: 1000, merchant_id: merchant1.id)
     item2 = Item.create!(name: "Pokemon stuffy", description: 'Pikachu stuffed toy', unit_price: 3000, merchant_id: merchant1.id)
@@ -192,22 +184,37 @@ RSpec.describe 'merchants invoice show page', type: :feature do
     transaction1 = Transaction.create!(credit_card_number: "123456789123456789", result: "success", invoice_id: invoice1.id)
     
     visit "/merchants/#{merchant1.id}/invoices/#{invoice1.id}"
+
+    expect(page).to have_content("Total revenue: 25000")
+    expect(page).to_not have_content("Total revenue: 1000")
+    expect(page).to have_content("Total revenue with bulk discount: 24000")  
+  end
+  
+  # save_and_open_page
+  # Merchant Invoice Show Page: Link to applied discounts
+
+  # As a merchant
+  # When I visit my merchant invoice show page
+  # Next to each invoice item I see a link to the show page 
+  # for the bulk discount that was applied (if any)
+  xit "has a link to the show page for the bulk discount if one was applied" do 
+    merchant1 = Merchant.create!(name: "Poke Retirement homes")
+    item1 = Item.create!(name: "Pikachu pics", description: 'Cute pics with pikachu', unit_price: 1000, merchant_id: merchant1.id)
+    item2 = Item.create!(name: "Pokemon stuffy", description: 'Pikachu stuffed toy', unit_price: 3000, merchant_id: merchant1.id)
+    customer1 = Customer.create!(first_name: "Parker", last_name: "Thomson")
+    invoice1 = Invoice.create!(status: "completed", customer_id: customer1.id)
+    bulk_discount1 = BulkDiscount.create!(quantity_threshold: 10, percentage: 10, merchant_id: merchant1.id)
     
-    expect(page).to have_content("Total Revenue: 5000")
-    expect(page).to_not have_content("Total Revenue: 1000")
-    
-    #bulk discount will be 10% off of 10 items
-    #item1 = 1000 * 10 - 10% = 9000
-    #item2 = no discount - 3000 * 5 = 15000
-    expect(page).to have_content("bulk discount: 10% off 10 items")
-    expect(page).to have_content("Total Revenue with bulk discount: 24000")
-    
-   
+    invoice_item1 = InvoiceItem.create!(quantity: 10, unit_price: item1.unit_price, status: "shipped", item_id: item1.id, invoice_id: invoice1.id)
+    invoice_item2 = InvoiceItem.create!(quantity: 5, unit_price: item2.unit_price, status: "shipped", item_id: item2.id, invoice_id: invoice1.id)
+    transaction1 = Transaction.create!(credit_card_number: "123456789123456789", result: "success", invoice_id: invoice1.id)
+
+    visit "/merchants/#{merchant1.id}/invoices/#{invoice1.id}"
+
+    expect(page).to have_content("Pikachu pics")
+    expect(page).to have_link('Bulk Discount Show Page')
+
+    expect(page).to have_content("Pokemon stuffy")
+    expect(page).to_not have_link('Bulk Discount Show Page')
   end
 end
-
-# merchant2 = Merchant.create!(name: "Rendolyn Guizs poke stops")
-# invoice2 = Invoice.create!(status: "completed", customer_id: customer1.id)
-# item3 = Item.create!(name: "Junk", description: 'junk you should want', unit_price: 500, merchant_id: merchant2.id)
-# invoice_item3 = InvoiceItem.create!(quantity: 1, unit_price: item3.unit_price, status: "shipped", item_id: item3.id, invoice_id: invoice2.id)
-# invoice2 = Invoice.create!(status: "completed", customer_id: customer1.id)

--- a/spec/models/bulk_discount_spec.rb
+++ b/spec/models/bulk_discount_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe BulkDiscount, type: :model do
 
   describe 'relationships' do
     it { should belong_to :merchant }
+    it { should have_many(:invoices).through(:merchant)}
   end
   
    describe 'validations' do

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe InvoiceItem do
   describe 'relationships' do
     it { should belong_to :invoice }
     it { should belong_to :item }
+    it { should have_many(:bulk_discounts).through(:merchant)}
   end
 
   describe 'validations' do

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Invoice do
     it { should have_many(:transactions) }
     it { should have_many(:items).through(:invoice_items) }
     it { should have_many(:merchants).through(:items)}
+    it { should have_many(:bulk_discounts).through(:merchants)}
   end
 
   describe 'validations' do
@@ -39,9 +40,9 @@ RSpec.describe Invoice do
       invoice_item2 = InvoiceItem.create!(quantity: 2, unit_price: item2.unit_price, status: "pending", item_id: item2.id, invoice_id: invoice1.id)
       invoice_item3 = InvoiceItem.create!(quantity: 3, unit_price: item3.unit_price, status: "packaged", item_id: item3.id, invoice_id: invoice3.id)
 
-      expect(invoice1.total_revenue(merchant1)).to eq(5000)
-      expect(invoice2.total_revenue(merchant2)).to eq(0)
-      expect(invoice3.total_revenue(merchant3)).to eq(1500)
+      expect(invoice1.total_revenue).to eq(5000)
+      expect(invoice2.total_revenue).to eq(0)
+      expect(invoice3.total_revenue).to eq(1500)
     end
   end
 


### PR DESCRIPTION
User story -completed 

Merchant Invoice Show Page: Total Revenue and Discounted Revenue
As a merchant
When I visit my merchant invoice show page
Then I see the total revenue for my merchant from this invoice (not including discounts)
And I see the total discounted revenue for my merchant from this invoice which includes bulk discounts in the calculation

refactored total_revenue method and updated spec tests, some tests should not have been passing but somehow did so method needed to be reworked. Created methods in invoice.rb and updated merchant/invoices show view to include discounted revenue. 