### PR TITLE
Merchant bulk discount show

### DIFF
--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -11,4 +11,8 @@ class InvoiceItem < ApplicationRecord
     validates_presence_of :quantity
     validates_presence_of :unit_price
     validates_presence_of :status
+
+    def get_max_discount
+        bulk_discounts.order("percentage desc").first
+    end
 end

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -21,6 +21,11 @@
       <p>Quantity: <%= invoice.quantity %></p>
       <p>Price: <%= invoice.unit_price %></p>
       <p>Status: <%= invoice.status %></p>
+      <% if !invoice.get_max_discount.nil? && invoice.quantity >= invoice.get_max_discount.quantity_threshold %>
+      <div id="discount-<%= invoice.id %>">
+        <h4><%=link_to 'Bulk Discount Show Page', "/merchants/#{@merchant.id}/bulk_discounts/#{invoice.get_max_discount.id}" %></h4>
+       </div>
+      <% end %>
       <%= form_with url: "/merchants/#{@merchant.id}/invoices/#{@invoice.id}", method: :post, local: true do |form| %>
       <%= form.select :status, options_for_select(InvoiceItem.statuses.map {|k, v| [k.capitalize, k.capitalize] }, selected: "#{invoice.status.capitalize}" ) %> 
       <%= hidden_field_tag "invoice_item_id", invoice.id %> 

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'merchants invoice show page', type: :feature do
 
     visit "/merchants/#{merchant1.id}/invoices/#{invoice1.id}"
 
-    within "div#invoice" do
+    within "#invoice" do
       expect(page).to have_content("Pikachu pics")
       expect(page).to have_content("shipped")
       expect(page).to have_content("Quantity: #{invoice_item1.quantity}")
@@ -39,7 +39,7 @@ RSpec.describe 'merchants invoice show page', type: :feature do
 
     visit "/merchants/#{merchant2.id}/invoices/#{invoice2.id}"
 
-    within "div#invoice" do
+    within "#invoice" do
       expect(page).to have_content("Pokemon stuffy")
       expect(page).to have_content("pending")
       expect(page).to have_content("Quantity: #{invoice_item2.quantity}")
@@ -56,7 +56,7 @@ RSpec.describe 'merchants invoice show page', type: :feature do
 
     visit "/merchants/#{merchant3.id}/invoices/#{invoice3.id}"
 
-    within "div#invoice" do
+    within "#invoice" do
       expect(page).to have_content("Junk")
       expect(page).to have_content("packaged")
       expect(page).to have_content("Quantity: #{invoice_item3.quantity}")
@@ -97,20 +97,20 @@ RSpec.describe 'merchants invoice show page', type: :feature do
 
     visit "/merchants/#{merchant1.id}/invoices/#{invoice1.id}"
 
-    within "div#revenue" do
+    within "#revenue" do
       expect(page).to have_content("Total revenue: 1000")
       expect(page).to_not have_content("2000")
     end
 
     visit "/merchants/#{merchant2.id}/invoices/#{invoice2.id}"
-    within "div#revenue" do
+    within "#revenue" do
       expect(page).to have_content("Total revenue: 4000")
       expect(page).to_not have_content("1000")
     end
 
     visit "/merchants/#{merchant3.id}/invoices/#{invoice3.id}"
 
-    within "div#revenue" do
+    within "#revenue" do
       expect(page).to have_content("Total revenue: 1500")
       expect(page).to_not have_content("1000")
       expect(page).to_not have_content("4000")
@@ -190,14 +190,7 @@ RSpec.describe 'merchants invoice show page', type: :feature do
     expect(page).to have_content("Total revenue with bulk discount: 24000")  
   end
   
-  # save_and_open_page
-  # Merchant Invoice Show Page: Link to applied discounts
-
-  # As a merchant
-  # When I visit my merchant invoice show page
-  # Next to each invoice item I see a link to the show page 
-  # for the bulk discount that was applied (if any)
-  xit "has a link to the show page for the bulk discount if one was applied" do 
+  it "has a link to the show page for the bulk discount if one was applied" do 
     merchant1 = Merchant.create!(name: "Poke Retirement homes")
     item1 = Item.create!(name: "Pikachu pics", description: 'Cute pics with pikachu', unit_price: 1000, merchant_id: merchant1.id)
     item2 = Item.create!(name: "Pokemon stuffy", description: 'Pikachu stuffed toy', unit_price: 3000, merchant_id: merchant1.id)
@@ -212,9 +205,12 @@ RSpec.describe 'merchants invoice show page', type: :feature do
     visit "/merchants/#{merchant1.id}/invoices/#{invoice1.id}"
 
     expect(page).to have_content("Pikachu pics")
-    expect(page).to have_link('Bulk Discount Show Page')
-
-    expect(page).to have_content("Pokemon stuffy")
-    expect(page).to_not have_link('Bulk Discount Show Page')
+    within "div#discount-#{invoice_item1.id}" do
+      expect(page).to have_link('Bulk Discount Show Page')
+      click_on ('Bulk Discount Show Page')
+      expect(current_path).to eq("/merchants/#{merchant1.id}/bulk_discounts/#{bulk_discount1.id}")
+    end
   end
 end
+
+

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -19,4 +19,37 @@ RSpec.describe InvoiceItem do
     it { should validate_presence_of :unit_price }
     it { should validate_presence_of :status }
   end
+
+  describe 'instance methods' do 
+    
+    it "can get the best bulk discount from a merchant" do 
+            merchant1 = Merchant.create!(name: "Poke Retirement homes")
+
+      item1 = Item.create!(name: "Pikachu pics", description: 'Cute pics with pikachu', unit_price: 1000, merchant_id: merchant1.id)
+      item2 = Item.create!(name: "Pokemon stuffy", description: 'Pikachu stuffed toy', unit_price: 3000, merchant_id: merchant1.id)
+      item3 = Item.create!(name: "Stickers", description: 'Pikachu sticker', unit_price: 100, merchant_id: merchant1.id)
+      item4 = Item.create!(name: "Button", description: 'Pikachu button', unit_price: 100, merchant_id: merchant1.id)
+
+      customer1 = Customer.create!(first_name: "Parker", last_name: "Thomson")
+
+      invoice1 = Invoice.create!(status: "completed", customer_id: customer1.id)
+      invoice2 = Invoice.create!(status: "completed", customer_id: customer1.id)
+      invoice3 = Invoice.create!(status: "completed", customer_id: customer1.id)
+
+      bulk_discount1 = BulkDiscount.create!(quantity_threshold: 10, percentage: 10, merchant_id: merchant1.id)
+      bulk_discount2 = BulkDiscount.create!(quantity_threshold: 5, percentage: 15, merchant_id: merchant1.id)
+
+      invoice_item1 = InvoiceItem.create!(quantity: 10, unit_price: item1.unit_price, status: "shipped", item_id: item1.id, invoice_id: invoice1.id)
+      invoice_item2 = InvoiceItem.create!(quantity: 5, unit_price: item2.unit_price, status: "shipped", item_id: item2.id, invoice_id: invoice2.id)
+      invoice_item3 = InvoiceItem.create!(quantity: 12, unit_price: item3.unit_price, status: "shipped", item_id: item3.id, invoice_id: invoice3.id)
+      
+      transaction1 = Transaction.create!(credit_card_number: "123456789123456789", result: "success", invoice_id: invoice1.id)
+      transaction2 = Transaction.create!(credit_card_number: "123456789144456789", result: "success", invoice_id: invoice2.id)
+      transaction3 = Transaction.create!(credit_card_number: "123456745123456789", result: "success", invoice_id: invoice3.id)
+
+      expect(invoice_item1.get_max_discount).to eq(bulk_discount2)
+      expect(invoice_item2.get_max_discount).to eq(bulk_discount2)
+      expect(invoice_item3.get_max_discount).to eq(bulk_discount2)     
+    end
+  end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe Invoice do
   describe 'instance methods' do
     it "can sum the invoices total revenue" do
       merchant1 = Merchant.create!(name: "Poke Retirement homes")
-      merchant2 = Merchant.create!(name: "Rendolyn Guizs poke stops")
-      merchant3 = Merchant.create!(name: "Dhirley Secasrio's knits and bits")
-
+      merchant2 = Merchant.create!(name: "Rendolyn Guizs poke stops", status: "enabled")
+      merchant3 = Merchant.create!(name: "Dhirley Secasrio's knits and bits", status: "enabled")
+      
       item1 = Item.create!(name: "Pikachu pics", description: 'Cute pics with pikachu', unit_price: 1000, merchant_id: merchant1.id)
       item2 = Item.create!(name: "Pokemon stuffy", description: 'Pikachu stuffed toy', unit_price: 2000, merchant_id: merchant1.id)
       item3 = Item.create!(name: "Junk", description: 'junk you should want', unit_price: 500, merchant_id: merchant3.id)
@@ -43,6 +43,62 @@ RSpec.describe Invoice do
       expect(invoice1.total_revenue).to eq(5000)
       expect(invoice2.total_revenue).to eq(0)
       expect(invoice3.total_revenue).to eq(1500)
+    end
+
+
+    it  "can get the bulk discount" do 
+      merchant1 = Merchant.create!(name: "Poke Retirement homes")
+
+      item1 = Item.create!(name: "Pikachu pics", description: 'Cute pics with pikachu', unit_price: 1000, merchant_id: merchant1.id)
+      item2 = Item.create!(name: "Pokemon stuffy", description: 'Pikachu stuffed toy', unit_price: 3000, merchant_id: merchant1.id)
+      item3 = Item.create!(name: "Stickers", description: 'Pikachu sticker', unit_price: 100, merchant_id: merchant1.id)
+      item4 = Item.create!(name: "Button", description: 'Pikachu button', unit_price: 100, merchant_id: merchant1.id)
+
+      customer1 = Customer.create!(first_name: "Parker", last_name: "Thomson")
+
+      invoice1 = Invoice.create!(status: "completed", customer_id: customer1.id)
+      invoice2 = Invoice.create!(status: "completed", customer_id: customer1.id)
+      invoice3 = Invoice.create!(status: "completed", customer_id: customer1.id)
+
+      bulk_discount1 = BulkDiscount.create!(quantity_threshold: 10, percentage: 10, merchant_id: merchant1.id)
+      
+      invoice_item1 = InvoiceItem.create!(quantity: 10, unit_price: item1.unit_price, status: "shipped", item_id: item1.id, invoice_id: invoice1.id)
+      invoice_item2 = InvoiceItem.create!(quantity: 5, unit_price: item2.unit_price, status: "shipped", item_id: item2.id, invoice_id: invoice2.id)
+      invoice_item3 = InvoiceItem.create!(quantity: 12, unit_price: item3.unit_price, status: "shipped", item_id: item3.id, invoice_id: invoice3.id)
+      invoice_item4 = InvoiceItem.create!(quantity: 1, unit_price: item3.unit_price, status: "shipped", item_id: item4.id, invoice_id: invoice3.id)
+      
+      transaction1 = Transaction.create!(credit_card_number: "123456789123456789", result: "success", invoice_id: invoice1.id)
+      transaction2 = Transaction.create!(credit_card_number: "123456789144456789", result: "success", invoice_id: invoice2.id)
+      transaction3 = Transaction.create!(credit_card_number: "123456745123456789", result: "success", invoice_id: invoice3.id)
+
+      expect(invoice1.revenue_with_discount).to eq(1000)
+      expect(invoice2.revenue_with_discount).to eq(0)
+      expect(invoice3.revenue_with_discount).to eq(120)
+    end
+
+    it "can return an invoices total discounted revenue" do
+      merchant1 = Merchant.create!(name: "Poke Retirement homes")
+      item1 = Item.create!(name: "Pikachu pics", description: 'Cute pics with pikachu', unit_price: 1000, merchant_id: merchant1.id)
+      item2 = Item.create!(name: "Pokemon stuffy", description: 'Pikachu stuffed toy', unit_price: 3000, merchant_id: merchant1.id)
+      item3 = Item.create!(name: "Stickers", description: 'Pikachu sticker', unit_price: 100, merchant_id: merchant1.id)
+      item4 = Item.create!(name: "Button", description: 'Pikachu button', unit_price: 100, merchant_id: merchant1.id)
+      customer1 = Customer.create!(first_name: "Parker", last_name: "Thomson")
+      invoice1 = Invoice.create!(status: "completed", customer_id: customer1.id)
+      invoice2 = Invoice.create!(status: "completed", customer_id: customer1.id)
+      invoice3 = Invoice.create!(status: "completed", customer_id: customer1.id)
+      bulk_discount1 = BulkDiscount.create!(quantity_threshold: 10, percentage: 10, merchant_id: merchant1.id)
+      
+      invoice_item1 = InvoiceItem.create!(quantity: 10, unit_price: item1.unit_price, status: "shipped", item_id: item1.id, invoice_id: invoice1.id)
+      invoice_item2 = InvoiceItem.create!(quantity: 5, unit_price: item2.unit_price, status: "shipped", item_id: item2.id, invoice_id: invoice2.id)
+      invoice_item3 = InvoiceItem.create!(quantity: 12, unit_price: item3.unit_price, status: "shipped", item_id: item3.id, invoice_id: invoice3.id)
+      invoice_item4 = InvoiceItem.create!(quantity: 1, unit_price: item3.unit_price, status: "shipped", item_id: item4.id, invoice_id: invoice3.id)
+      transaction1 = Transaction.create!(credit_card_number: "123456789123456789", result: "success", invoice_id: invoice1.id)
+      transaction2 = Transaction.create!(credit_card_number: "123456789144456789", result: "success", invoice_id: invoice2.id)
+      transaction3 = Transaction.create!(credit_card_number: "123456745123456789", result: "success", invoice_id: invoice3.id)
+
+      expect(invoice1.discounted_revenue).to eq(9000)
+      expect(invoice2.discounted_revenue).to eq(15000)
+      expect(invoice3.discounted_revenue).to eq(1180)
     end
   end
 


### PR DESCRIPTION
Worked on User Story 6 and 7 
Merchant Invoice Show Page: Total Revenue and Discounted Revenue
As a merchant
When I visit my merchant invoice show page
Then I see the total revenue for my merchant from this invoice (not including discounts)
And I see the total discounted revenue for my merchant from this invoice which includes bulk discounts in the calculation

Merchant Invoice Show Page: Link to applied discounts
As a merchant
When I visit my merchant invoice show page
Next to each invoice item I see a link to the show page for the bulk discount that was applied (if any)--- got them working, but I feel like user story 7 still needs some tweaking. Will work on it tomorrow. Link is only showing correctly now for US6, was busted on earlier attempts. 